### PR TITLE
RDAP Registro.BR

### DIFF
--- a/consulta/host/dominio/registrobr/rdap.yaml
+++ b/consulta/host/dominio/registrobr/rdap.yaml
@@ -1,0 +1,38 @@
+id: rdap_registrobr
+
+info:
+  name: RDAP WHOIS Registro.BR
+  description: |
+    O RDAP (Registration Data Access Protocol) é um padrão definido pelo IETF 
+    para substituir o protocolo whois em consultas de informações sobre 
+    registros de recursos Internet como nomes de domínios, endereços IP e ASNs.
+    Esse template utiliza o serviço de consulta RDAP do Registro.BR.
+  author: ricardomaia / OSINT Brazuca
+  severity: info
+  reference:
+    - https://registro.br/rdap/
+  tags: info,consulta,zwhois,rdap,osint
+  metadata:
+    exemplo: |
+      nuclei -t ./nuclei-templates-brazuca/consulta/host/dominio/registrobr/rdap.yaml -u https://www.google.com.br
+      nuclei -t ./nuclei-templates-brazuca/consulta/host/dominio/registrobr/rdap.yaml -l /caminho/arquivo/urls.txt
+
+requests:
+  - method: GET
+    headers:
+      User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36
+      authority: rdap.registro.br
+      Accept: "*/*"
+      Pragma: no-cache
+      Cache-Control: no-cache
+      sec-fetch-mode: navigate
+      sec-fetch-site: none
+      sec-fetch-dest: document
+    path:
+      - "https://rdap.registro.br/domain/{{Host}}"
+
+    extractors:
+      - type: json
+        part: body
+        json:
+          - "."


### PR DESCRIPTION
Este PR inclui um _template_ para consulta de domínios utilizando o serviço RDAP do Registro.BR ( que funciona somente  para domínios .BR)

Utilizei o padrão do próprio Nuclei ao invés de variáveis como argumento na linha de comando para que seja possível o encadeamento (pipeline) no processo de descoberta.

## Exemplos de Uso

### Especificando uma única URL
```console
nuclei -t ./nuclei-templates-brazuca/consulta/host/dominio/registrobr/rdap.yaml -u https://www.google.com.br
```

### Passando um arquivo de URLs como parâmetro
```console
nuclei -t ./nuclei-templates-brazuca/consulta/host/dominio/registrobr/rdap.yaml -l /caminho/arquivo/urls.txt
```